### PR TITLE
feat: リードタイム計算機能とGitHub CLI セットアップ手順の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ GitHub のプルリクエストから AI 利用率を分析し、CSV 形式で�
 - GitHub Personal Access Token
 - GitHub CLI（ラベル作成時）
 
+### GitHub CLI セットアップ
+
+ラベル作成機能を使用するには GitHub CLI が必要です：
+
+```bash
+# インストール
+# 詳細は公式ドキュメントを参照: https://github.com/cli/cli?tab=readme-ov-file#installation
+
+# Homebrew (macOS/Linux)
+brew install gh
+
+# 認証（初回のみ）
+gh auth login
+
+# Personal Access Token を環境変数に設定
+export GH_TOKEN=$(gh auth token)
+
+# SAML SSO 環境の場合は追加で認証更新
+gh auth refresh -s repo
+```
+
 ## 🔧 インストール
 
 ```bash
@@ -31,11 +52,19 @@ npm install
 
 ### 1. 環境変数の設定
 
-`.env`ファイルを作成して以下の環境変数を設定：
+GitHub CLI を使用している場合、token を自動取得できます：
+
+```bash
+# GitHub CLI の token を環境変数に設定
+export GH_TOKEN=$(gh auth token)
+```
+
+または `.env` ファイルを作成して設定：
 
 ```env
 # GitHub Personal Access Token
-GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# GitHub CLI使用時: export GH_TOKEN=$(gh auth token) で自動設定可能
+GH_TOKEN=gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # 対象リポジトリ（カンマ区切りで複数指定可能）
 GITHUB_REPOSITORIES=owner1/repo1,owner2/repo2

--- a/get-github-pull-requests.ts
+++ b/get-github-pull-requests.ts
@@ -165,8 +165,8 @@ const fetchAllPullRequests = async (
 };
 
 // CSV生成関数群
-const formatDate = (date: Date): string => {
-  return date.toISOString().split("T")[0];
+const formatDateTime = (date: Date): string => {
+  return date.toISOString().replace("T", " ").replace("Z", "");
 };
 
 const sanitizeBodyText = (body: string): string => {
@@ -204,10 +204,10 @@ const generateCSV = (prs: PullRequestData[]): string => {
     pr.author,
     pr.repository,
     pr.state,
-    formatDate(pr.createdAt),
-    formatDate(pr.updatedAt),
-    pr.mergedAt ? formatDate(pr.mergedAt) : "",
-    pr.closedAt ? formatDate(pr.closedAt) : "",
+    formatDateTime(pr.createdAt),
+    formatDateTime(pr.updatedAt),
+    pr.mergedAt ? formatDateTime(pr.mergedAt) : "",
+    pr.closedAt ? formatDateTime(pr.closedAt) : "",
     pr.aiUtilizationRate?.toString() ?? "",
     `"${pr.labels.join("; ")}"`,
     pr.url,
@@ -273,7 +273,7 @@ const processPullRequests = async (config: Config): Promise<void> => {
       .join(", ")}`
   );
   console.log(
-    `📅 期間: ${formatDate(config.dateRange.start)} 〜 ${formatDate(
+    `📅 期間: ${formatDateTime(config.dateRange.start)} 〜 ${formatDateTime(
       config.dateRange.end
     )}`
   );

--- a/get-github-pull-requests.ts
+++ b/get-github-pull-requests.ts
@@ -188,8 +188,8 @@ const formatDateTime = (date: Date): string => {
   }
   
   // YYYY-MM-DD hh:mm:ss形式で出力
-  // TZDateの場合は+09:00形式なので、それに対応
-  return targetDate.toISOString().replace('T', ' ').replace(/\.\d{3}(\+09:00|Z)$/, '');
+  // Asia/Tokyoタイムゾーン（+09:00）でローカル時刻を出力
+  return targetDate.toISOString().replace('T', ' ').replace(/\.\d{3}(Z|[+-]\d{2}:\d{2})$/, '');
 };
 
 const sanitizeBodyText = (body: string): string => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@date-fns/tz": "^1.4.1",
         "@octokit/rest": "^22.0.0",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.1"
@@ -17,6 +18,12 @@
         "@types/node": "^24.3.0",
         "tsx": "^4.20.4"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/seta-takumi/ai-usage-ratio#readme",
   "description": "",
   "dependencies": {
+    "@date-fns/tz": "^1.4.1",
     "@octokit/rest": "^22.0.0",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.1"


### PR DESCRIPTION
## Summary
- リードタイム（日）のカラムを追加し、作成日からマージ日までの日数を計算
- 日時表示を時刻まで含む形式に変更（Asia/Tokyo タイムゾーン対応）
- README.md に GitHub CLI のセットアップ手順を追加

## 技術的概要
- `@date-fns/tz` パッケージを追加してタイムゾーン対応を実装
- `calculateLeadTimeDays` 関数を追加してリードタイム計算ロジックを実装
- `formatDateTime` 関数で日時フォーマットを `YYYY-MM-DD hh:mm:ss` 形式に変更
- CSV出力に「Lead Time (Days)」カラムを追加
- GitHub CLI の認証と `gh auth token` による環境変数設定手順をドキュメント化

## Test plan
- [x] CSVファイルにLead Time (Days)カラムが追加されることを確認
- [x] マージされたPRのリードタイムが正しく計算されることを確認
- [x] 日時が YYYY-MM-DD hh:mm:ss 形式で出力されることを確認
- [x] GitHub CLI の手順に従ってセットアップできることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)