### PR TITLE
feat: AIラベル付きPRのみリードタイム計算対象とする仕様変更

### DIFF
--- a/get-github-pull-requests.ts
+++ b/get-github-pull-requests.ts
@@ -65,8 +65,8 @@ const extractAiUtilizationRate = (labels: string[]): number | null => {
   return match ? parseInt(match[1], 10) : null;
 };
 
-const calculateLeadTimeDays = (createdAt: Date, mergedAt: Date | null): number | null => {
-  if (!mergedAt) return null;
+const calculateLeadTimeDays = (createdAt: Date, mergedAt: Date | null, hasAiLabel: boolean): number | null => {
+  if (!mergedAt || !hasAiLabel) return null;
 
   const timeDiffMs = mergedAt.getTime() - createdAt.getTime();
   const timeDiffDays = timeDiffMs / (1000 * 60 * 60 * 24);
@@ -81,6 +81,9 @@ const transformPullRequest = (
 ): PullRequestData => {
   const createdAt = new TZDate(pr.created_at, "Asia/Tokyo");
   const mergedAt = pr.merged_at ? new TZDate(pr.merged_at, "Asia/Tokyo") : null;
+  const labels = pr.labels.map((l: any) => l.name);
+  const aiUtilizationRate = extractAiUtilizationRate(labels);
+  const hasAiLabel = aiUtilizationRate !== null;
 
   return {
     number: pr.number,
@@ -93,12 +96,10 @@ const transformPullRequest = (
     updatedAt: new TZDate(pr.updated_at, "Asia/Tokyo"),
     mergedAt,
     closedAt: pr.closed_at ? new TZDate(pr.closed_at, "Asia/Tokyo") : null,
-    aiUtilizationRate: extractAiUtilizationRate(
-      pr.labels.map((l: any) => l.name)
-    ),
-    labels: pr.labels.map((l: any) => l.name),
+    aiUtilizationRate,
+    labels,
     url: pr.html_url,
-    leadTimeDays: calculateLeadTimeDays(createdAt, mergedAt),
+    leadTimeDays: calculateLeadTimeDays(createdAt, mergedAt, hasAiLabel),
   };
 };
 


### PR DESCRIPTION
## Summary
リードタイム計算の対象を、AIラベル付きかつマージ済みのPRのみに限定する仕様変更を実装しました。これにより、AI利用率が不明なPRのリードタイムを除外し、AI活用効果の分析をより正確に行えるようになります。

## 技術的概要
- `calculateLeadTimeDays` 関数に `hasAiLabel` パラメータを追加
- AIラベル（AI0%～AI100%）が付いていないPRはリードタイム計算から除外
- マージされていないPRも引き続き除外対象
- `transformPullRequest` 関数内でラベル処理を最適化（重複計算を削除）

## 主な変更点

### 🎯 リードタイム計算ロジックの変更
**変更前**:
```typescript
const calculateLeadTimeDays = (createdAt: Date, mergedAt: Date | null): number | null => {
  if (!mergedAt) return null;
  // リードタイム計算
};
```

**変更後**:
```typescript
const calculateLeadTimeDays = (createdAt: Date, mergedAt: Date | null, hasAiLabel: boolean): number | null => {
  if (!mergedAt || !hasAiLabel) return null;
  // リードタイム計算（AIラベル付きPRのみ）
};
```

### 🔧 処理効率の最適化
- `pr.labels.map()` の重複実行を削除
- ラベル解析結果を変数に格納して再利用
- AI利用率とラベル有無の判定を一元化

## 影響範囲

### CSV出力への影響
- **Lead Time (Days)** カラム: AIラベルなしのPRは空欄になります
- 他のカラムに変更はありません

### 分析結果への影響
- リードタイム関連の統計（平均・最小・最大）からAIラベルなしのPRが除外されます
- AI利用率とリードタイムの相関分析がより正確になります

## 想定される効果

### 📊 分析精度の向上
- AI活用度とリードタイムの関係をより正確に把握可能
- AIを活用しないPRのノイズを除去
- 組織のAI活用効果の定量化が可能

### 🎯 運用での利点
- AI活用推進の効果測定が明確化
- チームごとのAI活用状況比較が容易
- リードタイム改善施策の効果検証が可能

## Test plan
- [x] AIラベル付きマージ済みPRのリードタイムが正しく計算されることを確認
- [x] AIラベルなしPRのリードタイムが `null` になることを確認
- [x] マージされていないPRのリードタイムが `null` になることを確認
- [x] CSV出力でAIラベルなしPRの Lead Time カラムが空欄になることを確認
- [x] 既存の統計機能に影響がないことを確認

## Breaking Changes
- **リードタイム統計**: AIラベルなしのPRが統計から除外されるため、既存データとの比較時に注意が必要
- **CSV出力**: Lead Time カラムの値が一部空欄になる可能性があります

## 今後の展望
この変更により、以下のような追加分析が可能になります：
- AI利用率別のリードタイム分布分析
- チーム・リポジトリ別のAI活用効果測定
- AI活用推進施策の効果検証

🤖 Generated with [Claude Code](https://claude.ai/code)